### PR TITLE
docs: discord-emoji-command としての README.md を作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,29 @@
-# wikipedian
+# discord-emoji-command
 
-Wikipedia　を検索する discord スラッシュコマンド。
+テキストから絵文字を生成・管理する Discord スラッシュコマンド Bot。
 
-![聖徳太子を検索している様子](/docs/wikipedian_usage.png)
+テキストを入力すると、そのテキストを絵文字化したリアクションを作成・更新できます。
 
-# 使い方
+## 機能
 
-- `/wikipedia word: 伊藤博文` : 「伊藤博文」を日本語版Wikipedia で検索した結果を表示
-- `/wikipedia word: Taylor Swift languages: en` : 「Taylor Swift」を英語版 Wikipediaで検索した結果を表示
-- `/wikipedia word: Taylor Swift languages: en,fr` : 「Taylor Swift」を英語版とフランス語版 Wikipedia で検索した結果を表示
+- Discord スラッシュコマンドによる絵文字管理
+- テキストから絵文字画像を自動生成
+- 絵文字の追加・更新
 
-# セットアップ
+## 開発状況
 
-## 1. Discord Application の作成
+> **Note:** 現在このリポジトリは [wikipedian](https://github.com/yuchiki/wikipedian) テンプレートから作成された初期状態です。今後、絵文字コマンドとしての機能を実装していきます。
+
+## 技術スタック
+
+- **ランタイム:** [Bun](https://bun.sh/)
+- **言語:** TypeScript
+- **フレームワーク:** [Discord.js](https://discord.js.org/) v14
+- **リンター/フォーマッター:** [Biome](https://biomejs.dev/)
+
+## セットアップ
+
+### 1. Discord Application の作成
 
 1. [Discord Developer Portal](https://discord.com/developers/applications) から Application を作成する
 2. General Information タブから `APPLICATION ID` をメモする
@@ -20,7 +31,7 @@ Wikipedia　を検索する discord スラッシュコマンド。
 4. OAuth2 タブの URL Generator から `applications.commands` と `bot` にチェックを入れてURLを生成する
 5. 生成されたURLに飛び、追加するサーバーを選んで Application を追加する
 
-## 2. `.env` ファイルの作成
+### 2. `.env` ファイルの作成
 
 リポジトリのルートに `.env` ファイルを作成する:
 
@@ -29,29 +40,22 @@ WIKIPEDIAN_CLIENT_ID=メモしたAPPLICATION ID
 WIKIPEDIAN_TOKEN=メモしたトークン
 ```
 
-## 3. 実行
-
-以下のいずれかの方法で実行する。
-
-### Docker の場合
+### 3. 実行
 
 ```sh
-docker pull ghcr.io/yuchiki/wikipedian:latest
-docker run --env-file=.env ghcr.io/yuchiki/wikipedian
-```
-
-### Kubernetes の場合
-
-1. `kubectl create secret generic wikipedian-secret --from-env-file=.env` で Secret を作成
-2. `kubectl apply -f` [manifests/wikipedian.yaml](/manifests/wikipedian.yaml) で deploy
-
-### Bun の場合
-
-Bun がインストールされている必要がある。
-
-```sh
-git clone https://github.com/yuchiki/wikipedian.git
-cd wikipedian
+git clone https://github.com/yuchiki/discord-emoji-command.git
+cd discord-emoji-command
 bun install
 bun run start
 ```
+
+## 開発コマンド
+
+| コマンド | 説明 |
+|---|---|
+| `bun install` | 依存関係のインストール |
+| `bun run start` | Bot の起動 |
+| `bun test` | テストの実行 |
+| `bun run format` | コードフォーマット (Biome) |
+| `bun run lint` | Lint (Biome) |
+| `bun run check` | フォーマット + Lint (Biome) |


### PR DESCRIPTION
## Summary
- wikipedian テンプレートの README を discord-emoji-command プロジェクト用に書き換え
- プロジェクトの目的（テキストから絵文字を生成・管理する Discord Bot）を記載
- 技術スタック、セットアップ手順、開発コマンド一覧を整理
- 現在テンプレートからの初期状態であることを開発状況として明記

Fixes #1

## Test plan
- [x] `bun test src/` — 全15テスト通過を確認
- [ ] README の内容がプロジェクトの意図と一致しているか目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)